### PR TITLE
fix: Prevent map error on products page

### DIFF
--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -223,9 +223,10 @@ function Home() {
     const fetchFeaturedProducts = async () => {
       try {
         const response = await axios.get('products/?ordering=-created_at&limit=6');
-        setFilteredProducts(response.data.results);
+        setFilteredProducts(response.data.results || []);
       } catch (err) {
         console.error('Error fetching featured products:', err);
+        setFilteredProducts([]);
       }
     };
 

--- a/frontend/src/components/Products.jsx
+++ b/frontend/src/components/Products.jsx
@@ -22,7 +22,7 @@ const Products = () => {
       setLoading(true);
       try {
         const response = await axios.get(`products/${location.search}`);
-        setProducts(response.data.results);
+        setProducts(response.data.results || []);
       } catch (err) {
         console.error("Error fetching products:", err);
         if (err.response) {
@@ -35,6 +35,7 @@ const Products = () => {
           console.error('Error', err.message);
         }
         setError('There was an error fetching the products.');
+        setProducts([]);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
- Initialize products state to an empty array.
- Handle cases where the API response does not contain a results property.