### PR TITLE
fix: Simplify product add routing

### DIFF
--- a/api/products/urls.py
+++ b/api/products/urls.py
@@ -10,6 +10,7 @@ from .views import (
 )
 
 router = DefaultRouter()
+router.register(r'products', ProductViewSet, basename='product')
 router.register(r'categories', CategoryViewSet, basename='category')
 router.register(r'cart', CartViewSet, basename='cart') # Manages the cart itself
 router.register(r'cart-items', CartItemViewSet, basename='cartitem') # Manages items in a cart
@@ -17,7 +18,5 @@ router.register(r'wishlist', WishlistViewSet, basename='wishlist')
 
 urlpatterns = [
     path('products/add/', add_product, name='product-add'),
-    path('products/', ProductViewSet.as_view({'get': 'list'}), name='product-list'),
-    path('products/<int:pk>/', ProductViewSet.as_view({'get': 'retrieve', 'put': 'update', 'patch': 'partial_update', 'delete': 'destroy'}), name='product-detail'),
     path('', include(router.urls)),
 ]


### PR DESCRIPTION
- Simplify the product URL configuration to resolve routing conflicts.
- Use a dedicated view and URL for adding products.