### PR TITLE
Fix product creation and update API

### DIFF
--- a/api/products/views.py
+++ b/api/products/views.py
@@ -45,14 +45,15 @@ class ProductViewSet(viewsets.ModelViewSet):
     def get_permissions(self):
         """
         Instantiates and returns the list of permissions that this view requires.
+        - 'create': User must be an authenticated farmer or supplier.
+        - 'update', 'partial_update', 'destroy': User must be the owner of the product.
+        - 'list', 'retrieve': Open to all.
         """
-        if self.action in ['create']:
+        if self.action == 'create':
             self.permission_classes = [permissions.IsAuthenticated, IsFarmerOrSupplier]
         elif self.action in ['update', 'partial_update', 'destroy']:
-            # IsOwnerOrReadOnly checks obj.farmer == request.user
-            # IsFarmerOrSupplier additionally checks user_type and obj.farmer for safety
-            self.permission_classes = [permissions.IsAuthenticated, IsFarmerOrSupplier, IsOwnerOrReadOnly]
-        else: # list, retrieve
+            self.permission_classes = [permissions.IsAuthenticated, IsOwnerOrReadOnly]
+        else:  # 'list', 'retrieve'
             self.permission_classes = [permissions.AllowAny]
         return super().get_permissions()
 

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -4,7 +4,6 @@ const axiosInstance = axios.create({
   baseURL: 'http://localhost:8000/api/',
   timeout: 5000,
   headers: {
-    'Content-Type': 'application/json',
     accept: 'application/json',
   },
 });


### PR DESCRIPTION
This commit addresses an issue where adding a product as a farmer or supplier would fail.

The following changes were made:

- Removed the default `Content-Type` header from the `axios` instance in the frontend to allow the browser to correctly set it for `multipart/form-data` requests.
- Simplified the permissions in the `ProductViewSet` to ensure that only authenticated farmers or suppliers can create products, and only the owner of a product can update or delete it.