### PR TITLE
I’ve explored the `accounts` app and found that the requested functio…

### DIFF
--- a/api/accounts/test_new_features.py
+++ b/api/accounts/test_new_features.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from .models import Region, UserProfile, FarmerProfile, SupplierProfile
+
+User = get_user_model()
+
+class UserRoleTests(TestCase):
+
+    def setUp(self):
+        self.region = Region.objects.create(name='Test Region', code='TR')
+
+    def test_create_buyer(self):
+        user = User.objects.create_user(
+            username='buyer',
+            email='buyer@test.com',
+            password='password',
+            role='buyer',
+            region=self.region
+        )
+        self.assertEqual(user.role, 'buyer')
+        self.assertTrue(UserProfile.objects.filter(user=user).exists())
+        self.assertFalse(FarmerProfile.objects.filter(user=user).exists())
+        self.assertFalse(SupplierProfile.objects.filter(user=user).exists())
+
+    def test_create_farmer(self):
+        user = User.objects.create_user(
+            username='farmer',
+            email='farmer@test.com',
+            password='password',
+            role='farmer',
+            region=self.region
+        )
+        self.assertEqual(user.role, 'farmer')
+        self.assertTrue(UserProfile.objects.filter(user=user).exists())
+        self.assertTrue(FarmerProfile.objects.filter(user=user).exists())
+        self.assertFalse(SupplierProfile.objects.filter(user=user).exists())
+
+    def test_create_supplier(self):
+        user = User.objects.create_user(
+            username='supplier',
+            email='supplier@test.com',
+            password='password',
+            role='supplier',
+            region=self.region
+        )
+        self.assertEqual(user.role, 'supplier')
+        self.assertTrue(UserProfile.objects.filter(user=user).exists())
+        self.assertFalse(FarmerProfile.objects.filter(user=user).exists())
+        self.assertTrue(SupplierProfile.objects.filter(user=user).exists())


### PR DESCRIPTION
…nality is already implemented. The `User` model already has a `role` field with choices for 'farmer', 'supplier', and 'buyer'. The `User` model also has a `region` field that is a foreign key to a `Region` model. The `RegisterSerializer` and `UserSerializer` already include the `role` and `region` fields. The `RegisterView` handles user registration and creates a `UserProfile`, `FarmerProfile`, or `SupplierProfile` based on the user's role. There are also `FarmerViewSet` and `SupplierViewSet` to list users with those roles. The URL configuration is already set up correctly to expose all the necessary endpoints. I created a new test file to verify the existing functionality, but was unable to run it due to environment issues.