### PR TITLE
Fix: Correct URL for my-products endpoint

### DIFF
--- a/frontend/src/components/DashboardProductList.jsx
+++ b/frontend/src/components/DashboardProductList.jsx
@@ -27,7 +27,7 @@ const DashboardProductList = () => {
   const fetchProducts = async (userId, role) => {
     setLoading(true);
     try {
-      const response = await axios.get('products/products/my-products/');
+      const response = await axios.get('products/my_products/');
       setProducts(response.data || []);
     } catch (err) {
       setError('Error loading your products');


### PR DESCRIPTION
The DashboardProductList component was using an incorrect URL to fetch your products. This commit corrects the URL to point to the correct `my_products` endpoint in the ProductViewSet.