### PR TITLE
feat: Hide scroll buttons by default

### DIFF
--- a/frontend/src/styles/CategoryMenu.css
+++ b/frontend/src/styles/CategoryMenu.css
@@ -25,6 +25,11 @@
   cursor: pointer;
   padding: 0 10px;
   transition: all 0.3s ease;
+  opacity: 0;
+}
+
+.category-menu-container:hover .scroll-btn {
+  opacity: 1;
 }
 
 .scroll-btn:hover {


### PR DESCRIPTION
- Update the CSS for the category menu to hide the scroll buttons by default and show them on hover.