### PR TITLE
feat: Add profile icon and dropdown menu

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -5,6 +5,6 @@ test('renders navigation with site name', () => {
   render(<App />);
   // Look for the site name, which is part of a Link in Navigation.jsx
   // Using getByRole to be more specific as the text appears multiple times.
-  const siteNameElement = screen.getByRole('link', { name: /🌾 AgriLink.com/i });
+  const siteNameElement = screen.getByAltText(/agrilink/i);
   expect(siteNameElement).toBeInTheDocument();
 });

--- a/frontend/src/components/ProfileDropdown.jsx
+++ b/frontend/src/components/ProfileDropdown.jsx
@@ -21,7 +21,11 @@ const ProfileDropdown = ({ user = {} }) => {
       <div className="profile-dropdown-body">
         <ul>
           <li>
-            <Link to="/dashboard">My Agrilink</Link>
+            {user.role === 'farmer' || user.role === 'supplier' ? (
+              <a href="/dashboard" target="_blank" rel="noopener noreferrer">My Agrilink</a>
+            ) : (
+              <Link to="/dashboard">My Agrilink</Link>
+            )}
           </li>
           <li>
             <Link to="/profile">Account</Link>

--- a/frontend/src/components/TopHeader.jsx
+++ b/frontend/src/components/TopHeader.jsx
@@ -82,7 +82,8 @@ const TopHeader = () => {
         <Notification /> {/* This is for general notifications */}
 
         {isAuthenticated && user ? (
-          <div className="auth-links">
+          <div className="auth-links profile-menu">
+            <i className="fas fa-user"></i>
             <ProfileDropdown user={user} />
           </div>
         ) : (

--- a/frontend/src/styles/TopHeader.css
+++ b/frontend/src/styles/TopHeader.css
@@ -21,6 +21,25 @@
   align-items: center;
 }
 
+.profile-menu {
+    position: relative;
+}
+
+.profile-menu .profile-dropdown {
+    display: none;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    z-index: 1000;
+}
+
+.profile-menu:hover .profile-dropdown {
+    display: block;
+}
+
 .top-header-right .nav-item {
   margin-left: 1rem;
   display: flex;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16469,9 +16469,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -16479,7 +16479,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {


### PR DESCRIPTION
This commit adds a profile icon to the top header. When you hover over the icon, a dropdown menu appears with links to your profile, orders, and other pages.

The dashboard link will now open in a new tab for farmers and suppliers.