### PR TITLE
fix: Allow customer registration

### DIFF
--- a/agrilink.log
+++ b/agrilink.log
@@ -1,1 +1,2 @@
 Watching for file changes with StatReloader
+Watching for file changes with StatReloader

--- a/api/accounts/models.py
+++ b/api/accounts/models.py
@@ -58,7 +58,7 @@ class User(AbstractUser):
     ROLE_CHOICES = [
         ('farmer', 'Farmer'),
         ('supplier', 'Supplier'),
-        ('buyer', 'Buyer'),
+        ('customer', 'Customer'),
     ]
     
     GENDER_CHOICES = [
@@ -68,7 +68,7 @@ class User(AbstractUser):
         ('prefer_not_to_say', 'Prefer not to say'),
     ]
     
-    role = models.CharField(max_length=20, choices=ROLE_CHOICES, default='buyer')
+    role = models.CharField(max_length=20, choices=ROLE_CHOICES, default='customer')
     region = models.ForeignKey(Region, on_delete=models.SET_NULL, null=True, blank=True)
     gender = models.CharField(max_length=20, choices=GENDER_CHOICES, null=True, blank=True)
     phone_number = models.CharField(

--- a/api/accounts/serializers.py
+++ b/api/accounts/serializers.py
@@ -50,6 +50,10 @@ class RegisterSerializer(serializers.ModelSerializer):
                 business_name=f"{user.first_name} {user.last_name}'s Business",
                 supplier_type='general'
             )
+        elif user.role == 'customer':
+            # For customers, a basic UserProfile is already created.
+            # You can add customer-specific profile logic here if needed in the future.
+            pass
         
         return user
 class UserSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This commit fixes a bug that prevented you from registering as "customer". The issue was that the frontend was sending "customer" as the role, but the backend was expecting "buyer".

This commit updates the backend to accept "customer" as a valid role. The `User` model and `RegisterSerializer` have been updated accordingly.